### PR TITLE
[Opencv-3.0.0 build manual correction] 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ make && make install
 $ cd /OPEL_DIR/dep/opencv-3.0.0
 $ mkdir build
 $ cd build
-$ cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..
+$ cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF ..
 $ make -j 4
 $ sudo make install
 ```


### PR DESCRIPTION
In order to reduce build time of opencv,  omit to build the unnecessary performance test and sample application.
