### PR TITLE
[Dependency Issue]OpenCV-3.0.0 build fail correction only modifying cmake file

### DIFF
--- a/dep/opencv-3.0.0/CMakeLists.txt
+++ b/dep/opencv-3.0.0/CMakeLists.txt
@@ -481,15 +481,36 @@ endif(WIN32 AND NOT MINGW)
 # ----------------------------------------------------------------------------
 if(UNIX)
   find_package(PkgConfig QUIET)
-	FIND_PATH( DBUS_INCLUDE_DIR dbus/dbus.h PATHS /usr/include/dbus-1.0 /usr/local/include/dbus-1.0 )
-	FIND_LIBRARY( DBUS_LIBRARY NAME dbus-1 PATHS /usr/lib /usr/local/lib )
-	FIND_PATH( DBUS_INCLUDE_LIB_DIR dbus/dbus-arch-deps.h PATHS /usr/lib/dbus-1.0/include /usr/local/lib/dbus-1.0/include /usr/lib/arm-linux-gnueabihf/dbus-1.0/include)
-	FIND_LIBRARY( DBUS_GLIB_LIBRARY NAME dbus-glib-1 PATHS /usr/lib /usr/local/lib )
-		
-	include(CheckFunctionExists)
+#	FIND_PATH( DBUS_INCLUDE_DIR dbus/dbus.h PATHS /usr/include/dbus-1.0 /usr/local/include/dbus-1.0 )
+#	FIND_LIBRARY( DBUS_LIBRARY NAME dbus-1 PATHS /usr/lib /usr/local/lib )
+#	FIND_LIBRARY( DBUS_GLIB_LIBRARY NAME dbus-glib-1 PATHS /usr/lib /usr/local/lib )
+find_path(DBUS_INCLUDE_DIR
+    NAMES
+    dbus/dbus.h
+    HINTS
+    ${DBUS_ROOT_DIR}
+    ${_dbus_hint_INCLUDE_DIRS}
+    PATH_SUFFIXES
+    include/
+    include/dbus-1.0/
+    dbus-1.0/
+)
+
+find_path(DBUS_ARCH_INCLUDE_DIR
+    NAMES
+    dbus/dbus-arch-deps.h
+    HINTS
+    ${DBUS_ROOT_DIR}
+    ${_dbus_hint_INCLUDE_DIRS}
+    PATHS
+    # TODO use CMAKE_SYSTEM_PROCESSOR or similar?
+    #/usr/lib/${CMAKE_SYSTEM_PROCESSOR}/dbus-1.0/include/
+    /usr/lib/i386-linux-gnu/dbus-1.0/include/
+    PATH_SUFFIXES
+    dbus-1.0/include/
+)	
+  include(CheckFunctionExists)
   include(CheckIncludeFile)
-	#	set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} DBUS_LIBRARY)
-	#	set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} DBUS_GLIB_LIBRARY)
 	if(NOT APPLE)
     CHECK_INCLUDE_FILE(pthread.h HAVE_LIBPTHREAD)
     if(ANDROID)
@@ -678,8 +699,8 @@ if(INSTALL_TESTS AND OPENCV_TEST_DATA_PATH)
                    "${CMAKE_BINARY_DIR}/win-install/opencv_run_all_tests.cmd" @ONLY)
     install(PROGRAMS "${CMAKE_BINARY_DIR}/win-install/opencv_run_all_tests.cmd"
             DESTINATION ${OPENCV_TEST_INSTALL_PATH} COMPONENT tests)
-  elseif(UNIX)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/opencv_run_all_tests_unix.sh.in"
+  elseif(UNIX)
                    "${CMAKE_BINARY_DIR}/unix-install/opencv_run_all_tests.sh" @ONLY)
     install(PROGRAMS "${CMAKE_BINARY_DIR}/unix-install/opencv_run_all_tests.sh"
             DESTINATION ${OPENCV_TEST_INSTALL_PATH} COMPONENT tests)

--- a/dep/opencv-3.0.0/modules/videoio/CMakeLists.txt
+++ b/dep/opencv-3.0.0/modules/videoio/CMakeLists.txt
@@ -101,17 +101,26 @@ if(HAVE_UNICAP)
 endif(HAVE_UNICAP)
 
 if(HAVE_LIBV4L)
- 
-#	include_directories(/usr/include/dbus-1.0)
-#	include_directories(/usr/lib/arm-linux-gnueabihf/dbus-1.0/include)
-	include_directories(${DBUS_INCLUDE_DIR})
-	include_directories(${DBUS_INCLUDE_LIB_DIR})
-list(APPEND videoio_srcs ${CMAKE_CURRENT_LIST_DIR}/src/cap_OPEL.cpp)
+	find_package(PkgConfig QUIET)
+	pkg_check_modules(_dbus_hint QUIET libdbus)
+	include_directories(/usr/include/dbus-1.0)
+	include_directories(/usr/lib/arm-linux-gnueabihf/dbus-1.0/include)
+  list(APPEND videoio_srcs ${CMAKE_CURRENT_LIST_DIR}/src/cap_OPEL.cpp)
 	list(APPEND VIDEOIO_LIBRARIES "-pthread")
+
+
+	#	list(APPEND VIDEOIO_LIBRARIES "dbus-1.0")
+	#list(APPEND VIDEOIO_LIBRARIES "glib-2.0")
 	list(APPEND VIDEOIO_LIBRARIES "-ldbus-1")
 	list(APPEND VIDEOIO_LIBRARIES "-ldbus-glib-1")
 elseif(HAVE_CAMV4L OR HAVE_CAMV4L2 OR HAVE_VIDEOIO)
+	#add_definitions(`pkg-config --libs --cflags dbus-1 glib-2.0 dbus-glib-1` -g `pkg-config --libs --cflags dbus-1 glib-2.0 dbus-glib-1`)
+
+	include_directories(/usr/include/dbus-1.0)
+	include_directories(/usr/lib/arm-linux-gnueabihf/dbus-1.0/include)
   list(APPEND videoio_srcs ${CMAKE_CURRENT_LIST_DIR}/src/cap_OPEL.cpp)
+	list(APPEND VIDEOIO_LIBRARIES "-ldbus-1")
+	list(APPEND VIDEOIO_LIBRARIES "-ldbus-glib-1")
 endif()
 
 if(HAVE_OPENNI)

--- a/dep/opencv-3.0.0/modules/videoio/src/cap_OPEL.cpp
+++ b/dep/opencv-3.0.0/modules/videoio/src/cap_OPEL.cpp
@@ -17,7 +17,6 @@
 #include <sys/wait.h>
 #include <sys/ipc.h>
 #include <sys/shm.h>
-//#include "/usr/include/dbus-1.0/dbus/dbus.h"
 #include <dbus/dbus.h>
 #include <semaphore.h>
 #include <linux/videodev2.h>


### PR DESCRIPTION
OpenCV-3.0.0이 build시 #include<dbus/dbus.h> header가 없어서 build가 실패하는 문제 해결 
