### PR TITLE
Camera Manager - Fix the NIL interface and Camera View app

### DIFF
--- a/src/api/camera/src/OPELRecordingAPI.cc
+++ b/src/api/camera/src/OPELRecordingAPI.cc
@@ -243,6 +243,7 @@ NAN_METHOD(OPELRecording::streamingStart)
     return;
   }
   dbus_request = new dbusStreamingRequest();
+	dbus_request->camera_num = camera_num;
   dbus_request->ip_address = ip_address;
   dbus_request->port = port;
   message = recObj->sendStreamingDbusMsg(streaming_start_request, dbus_request);
@@ -252,14 +253,26 @@ NAN_METHOD(OPELRecording::streamingStart)
 NAN_METHOD(OPELRecording::streamingStop)
 {
   OPELRecording *recObj = Nan::ObjectWrap::Unwrap<OPELRecording>(info.This());
+	DBusMessage* message;
+  dbusStreamingRequest *dbus_request;
+	unsigned camera_num;
+  if(!info[0]->IsNumber())
+  {
+    Nan::ThrowTypeError("First parameter should be Camera Number");
+    return;
+  }
+  camera_num = Nan::To<int>(info[0]).FromJust();  
+
   if(!(recObj->initDbus()))
   {
     Nan::ThrowError("D-Bus Initiailization Failed\n");
     return;
   }
-  DBusMessage* message;
-  message = dbus_message_new_signal(dbus_path, dbus_interface, streaming_stop_request);
-  dbus_connection_send(recObj->conn, message, NULL);
+	dbus_request = new dbusStreamingRequest();
+	dbus_request->camera_num = camera_num;
+	message = recObj->sendStreamingDbusMsg(streaming_stop_request, dbus_request);
+  //message = dbus_message_new_signal(dbus_path, dbus_interface, streaming_stop_request);
+  //dbus_connection_send(recObj->conn, message, NULL);
 }
 
 
@@ -385,7 +398,7 @@ NAN_MODULE_INIT(OPELRecording::Init)
   SetPrototypeMethod(tpl, "SnapshotStart", jpegStart);
 
   SetPrototypeMethod(tpl, "streamingStart", streamingStart);
-  SetPrototypeMethod(tpl, "streamingStart", streamingStart);
+  SetPrototypeMethod(tpl, "streamingStop", streamingStop);
 
   SetPrototypeMethod(tpl, "SensorOverlayStart", sensorOverlayStart);
   SetPrototypeMethod(tpl, "SensorOverlayStop", sensorOverlayStop);

--- a/src/appcore-manager/src/DbusManager.cpp
+++ b/src/appcore-manager/src/DbusManager.cpp
@@ -355,13 +355,12 @@ void DbusManager::sendTerminationToCameraManager(){
 		dbus_error_free(&err);
 		return ;
 	}
-	else{
+	/*else{
 		DBusMessage* msg;
 		msg = dbus_message_new_signal(interface_address, path_address, "recStop");
 		dbus_connection_send(conn, msg, NULL);
 		dbus_message_unref(msg);
-
-	}
+	}*/
 }
 
 

--- a/system-apps/CameraViewer/index.js
+++ b/system-apps/CameraViewer/index.js
@@ -21,12 +21,12 @@ var d;
 // streamObj.start(int n, function(err, data); n != 0 : finite Number of Frame n == 0 : Infinite Number of Frame 
 // streamObj.stop(); //aborting
 
-streamObj.streamingStart("192.168.49.1", 5000);
+streamObj.streamingStart(0, "192.168.49.1", 5000);
 
 
-nil.onTermination(function(){
+appApi.onTermination(function(){
 			console.log('<onTermination Called');
-			streamObj.streamingStop();
+			streamObj.streamingStop(0);
 		});
 
 


### PR DESCRIPTION
**Camera NIL Interface**

- RecordingStart (camera_num, file_path, seconds)
- RecordingStop (camera_num)
- SnapshotStart (camera_num, file_path)
- streamingStart (camera_num, ip_addr, port)
- streamingStop ((camera_num)
- SensorOverlayStart (camera_num, sensor_name)
- SensorOverlayStop (camera_num, sensor_name)