### PR TITLE
Fix the Raspberry Pi camera

### DIFF
--- a/src/camera-manager/src/OPELgstElementTx1.cpp
+++ b/src/camera-manager/src/OPELgstElementTx1.cpp
@@ -282,6 +282,10 @@ bool OPELGstElementTx1::OPELGstElementCapFactory(void)
         sprintf(caps_buffer, "video/x-raw");
       else
         return false;
+
+      sprintf(caps_buffer, "%s, format=(string){I420}, "
+          "width=(int){%d}, height=(int){%d}", caps_buffer,
+          prop_element->getWidth(), prop_element->getHeight());
       break;
     case RPI2_3:
       sprintf(caps_buffer, "video/x-raw");
@@ -289,9 +293,6 @@ bool OPELGstElementTx1::OPELGstElementCapFactory(void)
     default:
       return false;
   }
-  sprintf(caps_buffer, "%s, format=(string){I420}, "
-      "width=(int){%d}, height=(int){%d}", caps_buffer,
-      prop_element->getWidth(), prop_element->getHeight());
 
   src_element->caps = gst_caps_from_string(caps_buffer);
   if(src_element->caps == NULL)
@@ -319,8 +320,12 @@ bool OPELGstElementTx1::OPELGstElementCapFactory(void)
     return false;
   }
 
+if(g_target_type == TX1) {
   enc_element->caps = gst_caps_new_simple("video/x-h264",
       "stream-format", G_TYPE_STRING, "avc", NULL);
+} else if (g_target_type == RPI2_3) {
+  enc_element->caps = gst_caps_new_simple("video/x-h264",NULL);
+}
   
 #endif /* TARGET_SRC_IS_CAM */
 
@@ -374,8 +379,10 @@ bool OPELGstElementTx1::OPELGstPipelineMake(void)
   typeElement* cam_src;
   if (this->camera_num == 0)
     cam_src = findByElementNickname(this->_type_element_vector, "camerasrc");
-  else if (this->camera_num == 1)
+  else if (this->camera_num == 1) {
     cam_src = findByElementNickname(this->_type_element_vector, "camerasrc2");
+    g_object_set(G_OBJECT(cam_src->element), "device", "/dev/video1", NULL);	// TODO: device name
+  }
   else
     return false;
 

--- a/src/camera-manager/src/main.cpp
+++ b/src/camera-manager/src/main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv)
   OPELGstElementTx1::InitInstance();
   ////_pipeline = OPELGstElement::getPipeline();
 
-	for (unsigned camera_num=0; camera_num<2; camera_num++) {
+	for (unsigned camera_num=0; camera_num<OPEL_CAMERA_NUM; camera_num++) {
     OPELGstElementTx1 *tx1 = OPELGstElementTx1::getOPELGstElementTx1(camera_num);
     tx1->setElementPropertyVector(v_element_property);
 

--- a/target/raspberry-pi2_3/camera-config.xml
+++ b/target/raspberry-pi2_3/camera-config.xml
@@ -6,7 +6,7 @@
 		<count>14</count>
 		<item_version>0</item_version>
 		<item class_id="2" tracking_level="1" version="0" object_id="_0">
-			<element_name>v4l2src</element_name>
+			<element_name>rpicamsrc</element_name>
 			<element_nickname>camerasrc</element_nickname>
 			<element_type>0</element_type>
 			<element_sub_type>0</element_sub_type>

--- a/target/raspberry-pi2_3/install-deps-raspberry-pi2_3.sh
+++ b/target/raspberry-pi2_3/install-deps-raspberry-pi2_3.sh
@@ -125,6 +125,14 @@ cd ${OPEL_REPO_DIR}
 npm install nan
 sudo npm install -g node-gyp
 
+# Step 11. Install Gstreamer RPI camera source element
+cd ${OPEL_REPO_DIR}/dep
+git clone https://github.com/thaytan/gst-rpicamsrc.git
+cd gst-rpicamsrc
+./autogen.sh --prefix=/usr --libdir=/usr/lib/arm-linux-gnueabihf/
+make
+sudo make install
+
 WARN_COLO="\033[31;47m"
 INFO_COLO="\033[36m"
 INIT_COLO="\033[0m"

--- a/test/sample-camera-client/OPELdbusInterface.cpp
+++ b/test/sample-camera-client/OPELdbusInterface.cpp
@@ -205,6 +205,7 @@ static void send_stream_start(DBusConnection *conn)
   unsigned camera_num = 0;
   printf("Camera Number : ");
   scanf("%d", &camera_num);
+  port += camera_num;
 
 	dbus_message_append_args(message,
       DBUS_TYPE_UINT64, &camera_num,


### PR DESCRIPTION
This PR includes below
- Fix the Camera manager for Raspberry Pi camera working
- Add the ```rpicamsrc``` streamer element (It is powerful in RPI camera)

Related to #142 

Previously, I added a porting layer in Camera Manager for various hardware devices.
Unfortunately, Raspberry Pi camera was not working.

This problem is that the capability between elements has been set incorrectly. (especially resolution!!)
So, I removed the capability that caused the problem.

In the future, a consideration of capability is needed to specify the desired resolution.
I wil issue this point.